### PR TITLE
Fix invalid iterator comparison

### DIFF
--- a/src/include/miopen/db_record.hpp
+++ b/src/include/miopen/db_record.hpp
@@ -78,7 +78,7 @@ class DbRecord
         public:
         std::pair<const std::string&, TValue> operator*() const
         {
-            assert(it != InnerIterator{});
+            assert(!it->first.empty() && !it->second.empty());
             TValue value;
             value.Deserialize(it->second);
             return {it->first, value};


### PR DESCRIPTION
It is illegal to compare iterators of two different containers. Exception is raised in debug mode