### PR TITLE
Added missing search folder for OpenCL libaries

### DIFF
--- a/cmake/FindOpenCL.cmake
+++ b/cmake/FindOpenCL.cmake
@@ -44,6 +44,7 @@ if("${CMAKE_SIZEOF_VOID_P}" EQUAL "8")
         NAMES OpenCL
         HINTS
         ${OPENCL_ROOT}/lib
+		$ENV{OCL_ROOT}/lib		
         $ENV{AMDAPPSDKROOT}/lib
         $ENV{CUDA_PATH}/lib
         DOC "OpenCL dynamic library path"


### PR DESCRIPTION
Added potential path for OpenCL libaries. Previous version wouldn't find ocl_sdk_light\lib on Windows.